### PR TITLE
Fix a few typos in docs

### DIFF
--- a/docs/flakiness/argos-helpers.mdx
+++ b/docs/flakiness/argos-helpers.mdx
@@ -11,7 +11,7 @@ Enhance your visual tests with Argos SDKs: Use `data-visual-test` attributes to 
 
 For tailored visual testing, the `data-visual-test` attributes provide control over how elements appear in Argos screenshots. This can be especially useful for obscuring or modifying elements with dynamic content, like dates.
 
-- `[data-visual-test="transparent"]`: Renders the element transparent (`visiblity: hidden`).
+- `[data-visual-test="transparent"]`: Renders the element transparent (`visibility: hidden`).
 - `[data-visual-test="removed"]`: Removes the element from view (`display: none`).
 - `[data-visual-test="blackout"]`: Masks the element with a blackout effect.
 - `[data-visual-test-no-radius]`: Strips the border radius from the element.

--- a/docs/guides/run-on-preview-deployment.mdx
+++ b/docs/guides/run-on-preview-deployment.mdx
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: npx playwright test
         env:
-          # Use this environment variable as `baseUrl` in your plawright.config.ts
+          # Use this environment variable as `baseUrl` in your playwright.config.ts
           BASE_URL: ${{ github.event.deployment_status.environment_url }}
           # Argos uses GITHUB_TOKEN to collect branch and pull request information
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/learn/team-members-and-roles.mdx
+++ b/docs/learn/team-members-and-roles.mdx
@@ -127,7 +127,7 @@ Project level roles are available on Enterprise plans
 Project level roles provide fine-grained control and access to specific projects within a team. These roles are assigned to individuals and are restricted to the projects they're assigned to, allowing for precise access control while preserving the overarching security and integrity of the team.
 
 - **[Project Administrator](#project-administrator)**: Team owners and members inherently act as project administrators for every project. Project administrators can review builds, manage all project settings, and manage production environment variables
-- **[Project Reviewier](#project-reviewer)**: Can review builds.
+- **[Project Reviewer](#project-reviewer)**: Can review builds.
 - **[Project Viewer](#project-viewer)**: Has read-only access to a specific project.
 
 ### Project Administrator

--- a/docs/quickstart/cypress.mdx
+++ b/docs/quickstart/cypress.mdx
@@ -86,7 +86,7 @@ it("screenshot homepage", async ({ page }) => {
 <ScreenshotGuidesLink />
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Cypress example](https://github.com/argos-ci/argos/tree/main/examples/cypress)
 - [Cypress SDK reference](/cypress)

--- a/docs/quickstart/next.mdx
+++ b/docs/quickstart/next.mdx
@@ -45,7 +45,7 @@ Get the Argos Playwright SDK.
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Next.js example](https://github.com/argos-ci/argos/tree/main/examples/nextjs)
 - [Playwright SDK reference](/playwright)

--- a/docs/quickstart/playwright.mdx
+++ b/docs/quickstart/playwright.mdx
@@ -42,7 +42,7 @@ Get the Argos Playwright SDK.
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Playwright example](https://github.com/argos-ci/argos/tree/main/examples/playwright)
 - [Playwright SDK reference](/playwright)

--- a/docs/quickstart/puppeteer.mdx
+++ b/docs/quickstart/puppeteer.mdx
@@ -54,7 +54,7 @@ const puppeteer = require("puppeteer");
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Puppeteer example](https://github.com/argos-ci/argos/tree/main/examples/puppeteer)
 - [Puppeteer SDK reference](/puppeteer)

--- a/docs/quickstart/remix.mdx
+++ b/docs/quickstart/remix.mdx
@@ -45,7 +45,7 @@ Get the Argos Playwright SDK.
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Remix example](https://github.com/argos-ci/argos/tree/main/examples/remix)
 - [Playwright SDK reference](/playwright)

--- a/docs/quickstart/storybook.mdx
+++ b/docs/quickstart/storybook.mdx
@@ -60,7 +60,7 @@ Read the [Storycap documentation](https://github.com/reg-viz/storycap) to learn 
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [Argos + Storybook example](https://github.com/argos-ci/argos/tree/main/examples/storybook)
 - [Storycap documentation](https://github.com/reg-viz/storycap)

--- a/docs/quickstart/webdriverio.mdx
+++ b/docs/quickstart/webdriverio.mdx
@@ -52,7 +52,7 @@ Screenshots are stored in `screenshots/argos`, don't forget to add this folder t
 
 <Congratulation />
 
-## Additional ressources
+## Additional resources
 
 - [WebdriverIO SDK reference](/webdriverio)
 

--- a/docs/subscription/open-source.mdx
+++ b/docs/subscription/open-source.mdx
@@ -16,7 +16,7 @@ The project must not be for commercial use.
 
 - The project must be open source.
 - The project's usage of Argos falls within reasonable use limits.
-- The project must be willing to include the Argos banner bellow in the source repository's README.md file.
+- The project must be willing to include the Argos banner below in the source repository's README.md file.
 - The project should use a UTM tag in the format `?utm_source=[team-name]&utm_campaign=oss` for the banners.
 
 <div style={{ textAlign: "center" }}>


### PR DESCRIPTION
I noticed one typo "bellow" for "below" so I've raised a PR to fix _all_ the typos in one shot.