### PR TITLE
docs: stabilize text rendering to reduce screenshot flakiness

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -33,6 +33,7 @@
   * [Flaky Tests](learn/reliability-and-flakiness/flaky-tests/README.md "Playbook")
     * [Wait for Loading](learn/reliability-and-flakiness/flaky-tests/wait-for-loading.md)
     * [Stabilize Date & Time](learn/reliability-and-flakiness/flaky-tests/stabilize-date-and-time.md)
+    * [Stabilize Text Rendering](learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md)
     * [Browser Glitches](learn/reliability-and-flakiness/flaky-tests/browser-glitches.md)
     * [Argos Helpers](learn/reliability-and-flakiness/flaky-tests/argos-helpers.md)
   * [Tests Dashboard](learn/reliability-and-flakiness/tests-dashboard.md)

--- a/learn/reliability-and-flakiness/flaky-tests/README.md
+++ b/learn/reliability-and-flakiness/flaky-tests/README.md
@@ -21,14 +21,19 @@ Visual flakiness usually stems from one of the following:
 * **Animations and transitions**: Unhandled motion captured mid-frame.
 * **Resolution and scaling**: Screen size or pixel density differences between environments.
 
-### Fix the root cause
+### Best practices for stable screenshots
 
-Ignoring noise is useful, but the most reliable suite is one where flakiness is addressed at the source. The Playbook covers practical techniques:
+Ignoring noise is useful, but the most reliable suite is one where flakiness is addressed at the source. Follow these practices—each one targets a common cause above:
 
-* [Wait for Loading](wait-for-loading.md) — capture screenshots only after the page is fully loaded.
-* [Stabilize Date & Time](stabilize-date-and-time.md) — hide or freeze dynamic dates and times.
-* [Browser Glitches](browser-glitches.md) — standardize environments and handle rendering quirks.
-* [Argos Helpers](argos-helpers.md) — use `data-visual-test` attributes to control how dynamic elements are captured.
+* **Wait until the page is ready before capturing.** Mark loading elements with `aria-busy` so `argosScreenshot()` waits for them. → [Wait for Loading](wait-for-loading.md)
+* **Make dates and times deterministic.** Hide or freeze any value that changes between runs. → [Stabilize Date & Time](stabilize-date-and-time.md)
+* **Force consistent text rendering.** Disable subpixel text and font hinting so glyphs look identical on every machine. → [Stabilize Text Rendering](stabilize-text-rendering.md)
+* **Run the same environment everywhere, and tame rendering quirks.** Use the same OS and browser locally and on CI, and smooth over properties like `border-radius`. → [Browser Glitches](browser-glitches.md)
+* **Mask or hide unavoidable dynamic content.** Use `data-visual-test` attributes for anything you can't stabilize at the source. → [Argos Helpers](argos-helpers.md)
+
+{% hint style="success" %}
+**New to visual testing?** Start with [Stabilize Text Rendering](stabilize-text-rendering.md) and [Wait for Loading](wait-for-loading.md). Together they prevent the large majority of flaky screenshots.
+{% endhint %}
 
 ### Emphasis on accessibility
 

--- a/learn/reliability-and-flakiness/flaky-tests/browser-glitches.md
+++ b/learn/reliability-and-flakiness/flaky-tests/browser-glitches.md
@@ -4,6 +4,10 @@ Eliminate browser-induced visual discrepancies: Ensure consistent environments a
 
 Glitches can occur when your tests are not running in the same environment. Be sure to run your E2E tests in the exact same environment (OS and Browser).
 
+{% hint style="info" %}
+The most common cross-environment glitch is text rendering. See [Stabilize Text Rendering](stabilize-text-rendering.md) for the launch options that make glyphs render identically everywhere.
+{% endhint %}
+
 ### Border Radius
 
 Sometimes, the `border-radius` property can cause screenshots to appear differently across different browsers or devices.

--- a/learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md
+++ b/learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md
@@ -1,0 +1,72 @@
+# Stabilize Text Rendering
+
+Force consistent glyph rendering across operating systems: disable subpixel (LCD) text and font hinting so the same text looks identical on macOS, Linux, and CI—eliminating one of the most common sources of screenshot flakiness.
+
+### Why text causes flaky screenshots
+
+By default, Chromium renders text using two techniques that depend on the underlying operating system, GPU, and font stack:
+
+* **Subpixel (LCD) antialiasing** uses the red, green, and blue subpixels of a screen to smooth glyph edges. It leaves faint red/blue color fringing that differs from one machine to another.
+* **Font hinting** snaps glyphs to the pixel grid. The result varies between platforms, shifting antialiasing by a pixel here and there.
+
+The consequence: a screenshot captured locally on macOS rarely matches the exact same screenshot captured on a Linux CI runner. Argos sees these sub-pixel differences as real changes and reports false positives, even though no code changed.
+
+### The fix
+
+Launch Chromium with two flags that make text rendering deterministic:
+
+* `--disable-lcd-text` — forces **grayscale antialiasing** instead of subpixel rendering, removing the red/blue edge fringing.
+* `--font-render-hinting=none` — disables font hinting so glyph rasterization is **platform-independent**.
+
+{% tabs %}
+{% tab title="Playwright" %}
+Add the launch options to the `use` block of your Playwright configuration:
+
+{% code title="playwright.config.ts" %}
+```ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  use: {
+    launchOptions: {
+      args: ["--disable-lcd-text", "--font-render-hinting=none"],
+    },
+  },
+});
+```
+{% endcode %}
+{% endtab %}
+
+{% tab title="Storybook (Vitest)" %}
+Pass the launch options to the Playwright provider in your Vitest configuration:
+
+{% code title="vitest.config.ts" %}
+```ts
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: playwright({
+        launchOptions: {
+          args: ["--disable-lcd-text", "--font-render-hinting=none"],
+        },
+      }),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});
+```
+{% endcode %}
+{% endtab %}
+{% endtabs %}
+
+{% hint style="success" %}
+These flags make text rendering consistent **across** environments, so screenshots captured on your machine match those captured on CI.
+{% endhint %}
+
+{% hint style="info" %}
+Rendering flakiness is reduced even further when local and CI runs share the **exact same environment** (OS and browser). See [Browser Glitches](browser-glitches.md) for more on standardizing environments.
+{% endhint %}

--- a/quickstart/any-test-framework.md
+++ b/quickstart/any-test-framework.md
@@ -66,6 +66,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ### Additional resources
 
 * [Argos CLI reference](../sdks-reference/argos-command-line-interface-cli.md)

--- a/quickstart/cypress-quickstart.md
+++ b/quickstart/cypress-quickstart.md
@@ -122,6 +122,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ### Additional resources
 
 * [Cypress example](https://github.com/argos-ci/argos-javascript/tree/main/examples/cypress)

--- a/quickstart/playwright-quickstart.md
+++ b/quickstart/playwright-quickstart.md
@@ -82,12 +82,21 @@ export default defineConfig({
 
     // Capture screenshot after each test failure.
     screenshot: "only-on-failure",
+
+    // Stabilize text rendering so screenshots match across macOS and CI.
+    launchOptions: {
+      args: ["--disable-lcd-text", "--font-render-hinting=none"],
+    },
   },
 });
 ```
 {% endcode %}
 
 Playwright's [recording options](https://playwright.dev/docs/test-use-options#recording-options) facilitate the automated capture of screenshots upon test failures. Notably, these captured screenshots and traces are then automatically uploaded to Argos.
+
+{% hint style="success" %}
+The `launchOptions` above disable subpixel text and font hinting, so glyphs render identically on your machine and on CI. This single change prevents one of the most common causes of flaky screenshots—learn why in [Stabilize Text Rendering](../learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md).
+{% endhint %}
 {% endstep %}
 
 {% step %}
@@ -118,6 +127,10 @@ After committing and pushing your changes, the Argos check status will appear on
 **Note:** you need a reference build to compare your changes with. If you don't have one, builds will remain orphan until you run Argos on your reference branch.
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
+
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
 
 ### Additional resources
 

--- a/quickstart/puppeteer-quickstart.md
+++ b/quickstart/puppeteer-quickstart.md
@@ -87,6 +87,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ### Additional resources
 
 * [Puppeteer example](https://github.com/argos-ci/argos-javascript/tree/main/examples/puppeteer)

--- a/quickstart/storybook-quickstart/README.md
+++ b/quickstart/storybook-quickstart/README.md
@@ -66,6 +66,8 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
 
+import { playwright } from "@vitest/browser-playwright";
+
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { argosVitestPlugin } from "@argos-ci/storybook/vitest-plugin";
 
@@ -100,7 +102,12 @@ export default defineConfig({
           browser: {
             enabled: true,
             headless: true,
-            provider: "playwright",
+            provider: playwright({
+              // Stabilize text rendering so screenshots match across macOS and CI.
+              launchOptions: {
+                args: ["--disable-lcd-text", "--font-render-hinting=none"],
+              },
+            }),
             instances: [{ browser: "chromium" }],
           },
           setupFiles: [".storybook/vitest.setup.ts"],
@@ -114,6 +121,10 @@ export default defineConfig({
 
 {% hint style="info" %}
 Be sure to have already installed the [Storybook Vitest Addon](https://storybook.js.org/docs/writing-tests/integrations/vitest-addon) in your project.
+{% endhint %}
+
+{% hint style="success" %}
+The `launchOptions` above disable subpixel text and font hinting, so glyphs render identically on your machine and on CI. This single change prevents one of the most common causes of flaky screenshots—learn why in [Stabilize Text Rendering](../../learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md).
 {% endhint %}
 {% endstep %}
 
@@ -193,6 +204,10 @@ After committing and pushing your changes, the Argos check status will appear on
 **Note:** you need a reference build to compare your changes with. If you don't have one, builds will remain orphan until you run Argos on your reference branch.
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
+
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
 
 ### Additional resources
 

--- a/quickstart/storybook-quickstart/storybook-legacy-less-than-v8-quickstart.md
+++ b/quickstart/storybook-quickstart/storybook-legacy-less-than-v8-quickstart.md
@@ -98,6 +98,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ### Additional resources
 
 * [Argos + Storybook legacy example](https://github.com/argos-ci/argos-javascript/tree/main/examples/storybook-legacy)

--- a/quickstart/storybook-quickstart/storybook-test-runner-quickstart.md
+++ b/quickstart/storybook-quickstart/storybook-test-runner-quickstart.md
@@ -151,6 +151,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+## Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ## Additional resources
 
 * [Argos + Storybook + Test Runner example](https://github.com/argos-ci/argos-javascript/tree/main/examples/storybook-test-runner)

--- a/quickstart/webdriverio-quickstart.md
+++ b/quickstart/webdriverio-quickstart.md
@@ -86,6 +86,10 @@ After committing and pushing your changes, the Argos check status will appear on
 
 You can now review changes of your app for each pull request, avoid visual bugs and merge with confidence. Welcome on board!
 
+### Next step: keep your screenshots stable
+
+Now that Argos is running, the next thing to learn is how to keep your screenshots free of flakiness. Read [Best practices for stable screenshots](../learn/reliability-and-flakiness/flaky-tests/README.md) to avoid false positives before they reach your pull requests.
+
 ### Additional resources
 
 * [Argos WebdriverIO SDK reference](../sdks-reference/webdriverio.md)


### PR DESCRIPTION
## What

Someone solved a long-standing source of screenshot flakiness in [GitbookIO/gitbook#4318](https://github.com/GitbookIO/gitbook/pull/4318/): launching Chromium with `--disable-lcd-text` and `--font-render-hinting=none` so glyphs render identically on macOS (local) and Linux (CI). This PR brings that learning into the Argos docs.

## Changes

**Highlighted the fix in the quickstarts**
- `playwright-quickstart.md` — added `launchOptions` to the config `use` block + an explanatory hint.
- `storybook-quickstart/README.md` — switched to the function-form `playwright({ launchOptions })` provider with the `@vitest/browser-playwright` import + hint.

**New dedicated guide**
- `Stabilize Text Rendering` — explains *why* subpixel (LCD) antialiasing and font hinting cause false diffs, then gives the fix in tabs for Playwright and Storybook/Vitest. Added to `SUMMARY.md`.

**More didactic flaky-tests playbook**
- Reframed the playbook README as actionable best practices (practice → guide), with a "start here" hint.
- Cross-linked Browser Glitches ↔ the new guide.

**Positioned as the next read after the quickstart**
- Added a consistent "Next step: keep your screenshots stable" callout to the end of all 8 quickstarts, linking to the best-practices playbook.

## Note for reviewers

The Storybook config uses `import { playwright } from "@vitest/browser-playwright"` (current Vitest 4 provider package). If the repo targets Vitest 3, the import should be `@vitest/browser/providers/playwright` — worth confirming against the working config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)