### PR TITLE
docs: document tokenless project slug + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+This repository contains GitBook documentation, edited as markdown files synced with GitBook.
+
+## Always use the `writing-docs` skill
+
+Before creating or editing any documentation in this repo, invoke the **`writing-docs`** skill (`.claude/skills/writing-docs/SKILL.md`).
+
+It documents the GitBook authoring conventions you must follow:
+
+- GitBook content structure (pages, spaces, collections, `SUMMARY.md`, `.gitbook.yaml`)
+- Frontmatter fields and page configuration
+- GitBook-flavored markdown and custom block syntax (hints, tabs, cards, includes, etc.)
+- Reusable content, variables, and best practices
+
+Use it whenever you write, update, or restructure content under `docs/`, `learn/`, `quickstart/`, `sdks-reference/`, or any other markdown in this repository.

--- a/learn/integrations/github-tokenless-authentication.md
+++ b/learn/integrations/github-tokenless-authentication.md
@@ -58,6 +58,43 @@ jobs:
 
 If you want OIDC for internal PRs _and_ tokenless for fork PRs in the same workflow, add `id-token: write` to the job's `permissions` block. The SDK uses OIDC when GitHub issues a token and automatically falls back to tokenless on fork PRs where it doesn't.
 
+### Specify a project when several share a repository
+
+Tokenless authentication identifies your Argos project from the GitHub repository running the workflow. If you have **multiple Argos projects linked to the same repository**, Argos cannot tell which one the upload belongs to, and the upload is rejected.
+
+To disambiguate, pass the project slug (`account/project-name`) so Argos knows which project to use. You can set it three ways, all equivalent:
+
+{% tabs %}
+{% tab title="Environment variable" %}
+```yaml
+- run: npm run test:e2e
+  env:
+    ARGOS_PROJECT: my-account/my-project
+```
+{% endtab %}
+
+{% tab title="CLI flag" %}
+```bash
+argos upload ./screenshots --project my-account/my-project
+```
+{% endtab %}
+
+{% tab title="SDK option" %}
+```javascript
+import { upload } from "@argos-ci/core";
+
+await upload({
+  files: ["screenshots/**/*.png"],
+  project: "my-account/my-project",
+});
+```
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+You only need this when more than one Argos project is connected to the same GitHub repository. With a single linked project, tokenless resolves it automatically.
+{% endhint %}
+
 ### Limitations
 
 * **GitHub Actions only.** Tokenless authentication relies on the GitHub workflow run lookup. It does not work outside GitHub Actions — for other CI providers, use `ARGOS_TOKEN`.
@@ -69,6 +106,8 @@ If you want OIDC for internal PRs _and_ tokenless for fork PRs in the same workf
 **`No matching workflow run found`.** Argos could not find an in-progress workflow run on GitHub matching the commit and branch the SDK reported. Check that the repository linked to the Argos project matches the one running the workflow, and that the workflow is still in progress when the upload runs.
 
 **`Repository does not match the Argos project`.** The repository running the workflow is not the one linked to the Argos project. Update the project's connected repository in Argos, or run the workflow from the linked repository.
+
+**`Multiple projects are linked to this repository`.** More than one Argos project is connected to the repository, so tokenless cannot pick one automatically. Specify which project to use with the project slug — see [Specify a project when several share a repository](#specify-a-project-when-several-share-a-repository).
 
 **Uploads work but are missing pull request metadata.** Tokenless authenticates the upload but does not by itself link the build to a pull request. Pass `GITHUB_TOKEN` in the job environment so the SDK can resolve the PR — see Running without `GITHUB_TOKEN`.
 

--- a/sdks-reference/argos-command-line-interface-cli.md
+++ b/sdks-reference/argos-command-line-interface-cli.md
@@ -114,6 +114,36 @@ bun x argos upload ./screenshots
 
 Use `-f` or `--files` to upload text-based artifacts such as JSON, YAML, XML, HTML, Markdown, CSS, or JavaScript files. See [Compare non-image files](../learn/how-to-guides/visual-coverage/compare-non-image-files.md) for examples and the full list of supported content types.
 
+#### Specify the project
+
+Use `--project <slug>` to set the Argos project slug (`account/project-name`). This disambiguates [tokenless authentication](../learn/integrations/github-tokenless-authentication.md) when multiple Argos projects are linked to the same repository. You can also set it with the `ARGOS_PROJECT` environment variable.
+
+{% tabs %}
+{% tab title="npm" %}
+```
+npm exec -- argos upload ./screenshots --project my-account/my-project
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```
+yarn run argos upload ./screenshots --project my-account/my-project
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```
+pnpm exec -- argos upload ./screenshots --project my-account/my-project
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```
+bun x argos upload ./screenshots --project my-account/my-project
+```
+{% endtab %}
+{% endtabs %}
+
 #### Debug mode
 
 You can enable debug mode by setting the `DEBUG` environment variable.


### PR DESCRIPTION
## Summary

Documents the new Argos **project slug** (`account/project-name`) for tokenless GitHub Actions authentication, added in [argos-ci/argos-javascript#318](https://github.com/argos-ci/argos-javascript/pull/318). The slug disambiguates which project an upload belongs to when multiple Argos projects are linked to the same GitHub repository, and is settable three equivalent ways: the `project` SDK option, the `--project <slug>` CLI flag, or the `ARGOS_PROJECT` environment variable.

## Changes

- **learn/integrations/github-tokenless-authentication.md** — new *"Specify a project when several share a repository"* section (env var / CLI flag / SDK option tabs), plus a matching `Multiple projects are linked to this repository` troubleshooting entry.
- **sdks-reference/argos-command-line-interface-cli.md** — document `--project <slug>` and `ARGOS_PROJECT` under the upload command.
- **AGENTS.md** — instruct agents to use the `writing-docs` skill before editing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)