### PR TITLE
docs: add API reference guides (introduction, pagination, rate limits, errors)

### DIFF
--- a/api-reference/SUMMARY.md
+++ b/api-reference/SUMMARY.md
@@ -1,5 +1,9 @@
 # Table of contents
 
+* [Introduction](introduction.md)
+* [Pagination](pagination.md)
+* [Rate limits](rate-limits.md)
+* [Errors](errors.md)
 * ```yaml
   type: builtin:openapi
   props:

--- a/api-reference/errors.md
+++ b/api-reference/errors.md
@@ -1,0 +1,68 @@
+---
+description: >-
+  Learn how the Argos API reports errors, the shape of an error response,
+  and what each HTTP status code means.
+icon: triangle-exclamation
+---
+
+# Errors
+
+Argos uses conventional HTTP status codes to indicate whether a request succeeded or failed, and returns a consistent JSON body describing what went wrong.
+
+## Error response shape
+
+When a request fails, the response body contains an `error` message. For validation failures, an optional `details` array breaks down each problem.
+
+```json
+{
+  "error": "Invalid request",
+  "details": [
+    {
+      "message": "perPage must be less than or equal to 100"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `error` | string | A human-readable description of the error. |
+| `details` | array | Optional. A list of `{ "message": string }` objects with field-level details, typically present on validation errors. |
+
+## Status codes
+
+| Status | Meaning | What to do |
+| --- | --- | --- |
+| `400 Bad Request` | The request body or a query parameter was invalid. | Check the `details` array and fix the offending fields. |
+| `401 Unauthorized` | The token is missing or invalid. | Verify the `Authorization` header and that your token is correct. |
+| `403 Forbidden` | The token is valid but lacks access to this resource. | Make sure the token belongs to the project you're targeting. |
+| `404 Not Found` | The requested resource doesn't exist. | Check the URL, including the owner and project slugs. |
+| `409 Conflict` | The request conflicts with the resource's current state. | For example, finalizing a build that's already finalized — fetch the latest state and retry if needed. |
+| `429 Too Many Requests` | You've exceeded the [rate limit](rate-limits.md). | Wait for the `Retry-After` window, then retry. |
+| `500 Internal Server Error` | Something went wrong on Argos's side. | Retry after a short delay. If it persists, [contact support](https://argos-ci.com/contact). |
+| `503 Service Unavailable` | Argos is temporarily unavailable. | Retry after a short delay. |
+
+## Handling errors
+
+Always check the response status before parsing the result. Status codes in the `2xx` range indicate success; anything else carries an error body you can inspect.
+
+```javascript
+const response = await fetch("https://api.argos-ci.com/v2/project", {
+  headers: { Authorization: `Bearer ${process.env.ARGOS_TOKEN}` },
+});
+
+if (!response.ok) {
+  const { error, details } = await response.json();
+  throw new Error(
+    details?.length
+      ? `${error}: ${details.map((d) => d.message).join(", ")}`
+      : error,
+  );
+}
+
+const project = await response.json();
+```
+
+{% hint style="info" %}
+For `429` and `5xx` responses, retrying with a short delay is usually the right move. For `4xx` responses other than `429`, the request won't succeed until you change something, so inspect the `error` message instead of retrying.
+{% endhint %}

--- a/api-reference/introduction.md
+++ b/api-reference/introduction.md
@@ -1,0 +1,121 @@
+---
+description: >-
+  Learn how to authenticate and make requests to the Argos REST API to
+  create builds, fetch results, and automate your visual testing workflow.
+icon: book-open
+---
+
+# Introduction
+
+The Argos API is organized around [REST](https://en.wikipedia.org/wiki/REST). It has predictable, resource-oriented URLs, accepts and returns [JSON](https://www.json.org)-encoded payloads, and uses standard HTTP response codes, authentication, and verbs.
+
+Most of the time you'll interact with Argos through one of the [SDKs](https://argos-ci.com/docs/sdks-reference/playwright) or the [CLI](https://argos-ci.com/docs/sdks-reference/argos-command-line-interface-cli), which call this API for you. You can also call it directly to build your own integrations.
+
+## Base URL
+
+All requests are made to the following base URL:
+
+```
+https://api.argos-ci.com/v2
+```
+
+{% hint style="info" %}
+The API is served over HTTPS only. Requests made over plain HTTP will fail.
+{% endhint %}
+
+## Authentication
+
+The Argos API authenticates requests with a **bearer token**. Add an `Authorization` header to every request, using your token as the credential:
+
+```
+Authorization: Bearer <your-token>
+```
+
+In most cases this is a **project token**, which you can find in your project settings on [argos-ci.com](https://argos-ci.com). A project token grants access to a single project, so it's safe to use in your CI environment.
+
+{% hint style="warning" %}
+Your token carries the ability to create and update builds in your project. Keep it secret: store it as a CI secret or environment variable, and never commit it to version control or expose it in client-side code.
+{% endhint %}
+
+Requests without a valid token return a [`401 Unauthorized`](errors.md) response.
+
+## Making a request
+
+Here's a complete example that fetches the project associated with your token:
+
+{% tabs %}
+{% tab title="cURL" %}
+```bash
+curl https://api.argos-ci.com/v2/project \
+  -H "Authorization: Bearer $ARGOS_TOKEN"
+```
+{% endtab %}
+
+{% tab title="JavaScript" %}
+```javascript
+const response = await fetch("https://api.argos-ci.com/v2/project", {
+  headers: {
+    Authorization: `Bearer ${process.env.ARGOS_TOKEN}`,
+  },
+});
+
+const project = await response.json();
+```
+{% endtab %}
+{% endtabs %}
+
+## Response codes
+
+Argos uses conventional HTTP response codes to indicate the success or failure of a request. In general:
+
+- Codes in the `2xx` range indicate success.
+- Codes in the `4xx` range indicate an error that resulted from the information provided (for example, a missing token, an invalid parameter, or a resource that doesn't exist).
+- Codes in the `5xx` range indicate an error on Argos's side.
+
+| Status | Meaning |
+| --- | --- |
+| `200 OK` | The request succeeded. |
+| `201 Created` | The resource was created (for example, a new build). |
+| `400 Bad Request` | The request was malformed or a parameter was invalid. |
+| `401 Unauthorized` | The token is missing or invalid. |
+| `403 Forbidden` | The token is valid but doesn't have access to this resource. |
+| `404 Not Found` | The requested resource doesn't exist. |
+| `409 Conflict` | The request conflicts with the current state of the resource. |
+| `429 Too Many Requests` | You've hit the [rate limit](rate-limits.md). |
+| `500 Internal Server Error` | Something went wrong on Argos's side. |
+| `503 Service Unavailable` | Argos is temporarily unavailable. |
+
+See [Errors](errors.md) for the shape of error responses and how to handle them.
+
+## OpenAPI specification
+
+The full API is described by an [OpenAPI 3.1](https://www.openapis.org) specification. You can download it to generate clients or explore the API in your favorite tooling:
+
+```
+https://api.argos-ci.com/v2/openapi.yaml
+```
+
+## Next steps
+
+<table data-view="cards">
+  <thead>
+    <tr>
+      <th>Topic</th>
+      <th data-card-target data-type="content-ref">Link</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Pagination</strong> — page through large lists of results.</td>
+      <td><a href="pagination.md">Pagination</a></td>
+    </tr>
+    <tr>
+      <td><strong>Rate limits</strong> — understand request limits and headers.</td>
+      <td><a href="rate-limits.md">Rate limits</a></td>
+    </tr>
+    <tr>
+      <td><strong>Errors</strong> — handle error responses gracefully.</td>
+      <td><a href="errors.md">Errors</a></td>
+    </tr>
+  </tbody>
+</table>

--- a/api-reference/pagination.md
+++ b/api-reference/pagination.md
@@ -1,0 +1,114 @@
+---
+description: >-
+  Page through large collections such as builds and diffs using Argos's
+  page-based pagination.
+icon: list-ol
+---
+
+# Pagination
+
+List endpoints — such as listing a project's builds or a build's diffs — can return more results than fit in a single response. These endpoints use **page-based pagination** so you can fetch results one page at a time.
+
+## Query parameters
+
+Control pagination with two optional query parameters:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `page` | integer | `1` | The page number to retrieve, starting at `1`. |
+| `perPage` | integer | `30` | The number of items per page. Must be between `1` and `100`. |
+
+## Response shape
+
+Every paginated endpoint returns the same envelope: a `pageInfo` object describing the current page and a `results` array containing the items.
+
+```json
+{
+  "pageInfo": {
+    "total": 248,
+    "page": 1,
+    "perPage": 30
+  },
+  "results": [
+    {
+      "id": "123",
+      "number": 248
+      // ...
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `pageInfo.total` | integer | The total number of items across all pages. |
+| `pageInfo.page` | integer | The current page number. |
+| `pageInfo.perPage` | integer | The number of items per page. |
+| `results` | array | The items for the current page. |
+
+## Fetching a page
+
+Request the second page of builds, 50 at a time:
+
+{% tabs %}
+{% tab title="cURL" %}
+```bash
+curl "https://api.argos-ci.com/v2/projects/my-team/my-project/builds?page=2&perPage=50" \
+  -H "Authorization: Bearer $ARGOS_TOKEN"
+```
+{% endtab %}
+
+{% tab title="JavaScript" %}
+```javascript
+const url = new URL(
+  "https://api.argos-ci.com/v2/projects/my-team/my-project/builds",
+);
+url.searchParams.set("page", "2");
+url.searchParams.set("perPage", "50");
+
+const response = await fetch(url, {
+  headers: { Authorization: `Bearer ${process.env.ARGOS_TOKEN}` },
+});
+
+const { pageInfo, results } = await response.json();
+```
+{% endtab %}
+{% endtabs %}
+
+## Iterating over all pages
+
+Use `pageInfo.total` and `perPage` to compute how many pages exist, then loop until you've fetched them all.
+
+```javascript
+async function fetchAllBuilds(owner, project) {
+  const perPage = 100;
+  let page = 1;
+  const builds = [];
+
+  while (true) {
+    const url = new URL(
+      `https://api.argos-ci.com/v2/projects/${owner}/${project}/builds`,
+    );
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("perPage", String(perPage));
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${process.env.ARGOS_TOKEN}` },
+    });
+    const { pageInfo, results } = await response.json();
+
+    builds.push(...results);
+
+    if (page * pageInfo.perPage >= pageInfo.total) {
+      break;
+    }
+    page += 1;
+  }
+
+  return builds;
+}
+```
+
+{% hint style="info" %}
+When iterating over many pages, keep the [rate limits](rate-limits.md) in mind and pick a larger `perPage` (up to `100`) to reduce the number of requests.
+{% endhint %}

--- a/api-reference/rate-limits.md
+++ b/api-reference/rate-limits.md
@@ -1,0 +1,55 @@
+---
+description: >-
+  Understand the Argos API rate limits, the headers returned on every
+  response, and how to handle 429 responses.
+icon: gauge-high
+---
+
+# Rate limits
+
+To keep the API fast and reliable for everyone, Argos limits how many requests you can make in a given window.
+
+## The limit
+
+The default rate limit is **500 requests every 5 minutes**, applied per token.
+
+If you exceed it, the API responds with a [`429 Too Many Requests`](errors.md) status code and rejects the request until the window resets.
+
+## Rate limit headers
+
+Every response includes [standard rate limit headers](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/) so you can track your usage without guessing:
+
+| Header | Description |
+| --- | --- |
+| `RateLimit-Limit` | The maximum number of requests allowed in the current window. |
+| `RateLimit-Remaining` | The number of requests remaining in the current window. |
+| `RateLimit-Reset` | The number of seconds until the window resets. |
+
+When you receive a `429` response, a `Retry-After` header tells you how many seconds to wait before retrying.
+
+## Handling 429 responses
+
+The recommended way to deal with rate limits is to **respect the `Retry-After` header** and back off before retrying. Here's a small helper that retries a request once it's allowed:
+
+```javascript
+async function requestWithRetry(url, options) {
+  while (true) {
+    const response = await fetch(url, options);
+
+    if (response.status !== 429) {
+      return response;
+    }
+
+    const retryAfter = Number(response.headers.get("Retry-After")) || 1;
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+  }
+}
+```
+
+{% hint style="info" %}
+To stay well under the limit when processing large amounts of data, increase your [page size](pagination.md) and avoid firing requests concurrently. Spacing requests out is almost always more reliable than retrying after a `429`.
+{% endhint %}
+
+## Need a higher limit?
+
+If your integration consistently bumps into the rate limit, [contact support](https://argos-ci.com/contact) to discuss your use case.


### PR DESCRIPTION
## Summary

Adds four guide pages to the `api-reference` space, modeled on Resend's API reference set but filled with Argos's real API details (sourced from `argos-ci/argos` backend `apps/backend/src/api`):

- **Introduction** — base URL (`https://api.argos-ci.com/v2`), HTTPS-only, `Authorization: Bearer` project-token auth, a working request example, the response-code table, and the OpenAPI spec link (`/v2/openapi.yaml`).
- **Pagination** — page-based scheme: `page` (default `1`) and `perPage` (default `30`, max `100`), the `{ pageInfo: { total, page, perPage }, results: [] }` envelope, and a loop to iterate all pages.
- **Rate limits** — 500 requests / 5 minutes per token, draft-8 `RateLimit-*` headers plus `Retry-After`, and a `429` retry helper.
- **Errors** — error body shape (`{ error, details? }`) and the HTTP status codes used (400/401/403/404/409/429/500/503).

All four are wired into `api-reference/SUMMARY.md` above the existing OpenAPI reference page.

## Notes

- Authored following the `writing-docs` / GitBook conventions (hints, tabs, cards, relative links, frontmatter icons).
- Token docs emphasize the **project token** (matches the OpenAPI security scheme); PATs/OIDC tokens are also accepted but not called out separately.
- Pagination examples use placeholder `my-team/my-project` slugs.
- Not yet rendered in a GitBook preview — worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)