### PR TITLE
docs: document waitForBackgroundImages stabilization option

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
   * [Flaky test detection](learn/reliability-and-flakiness/flaky-test-detection.md)
   * [Flaky tests](learn/reliability-and-flakiness/flaky-tests/README.md "Playbook")
     * [Wait for loading](learn/reliability-and-flakiness/flaky-tests/wait-for-loading.md)
+    * [Wait for background images](learn/reliability-and-flakiness/flaky-tests/wait-for-background-images.md)
     * [Stabilize date & time](learn/reliability-and-flakiness/flaky-tests/stabilize-date-and-time.md)
     * [Stabilize text rendering](learn/reliability-and-flakiness/flaky-tests/stabilize-text-rendering.md)
     * [Browser glitches](learn/reliability-and-flakiness/flaky-tests/browser-glitches.md)

--- a/docs/learn/reliability-and-flakiness/flaky-tests/README.md
+++ b/docs/learn/reliability-and-flakiness/flaky-tests/README.md
@@ -35,6 +35,7 @@ Most stabilization is automatic. The Argos SDK stabilizes every screenshot by de
 {% endhint %}
 
 * **Wait until the page is ready before capturing.** Mark loading elements with `aria-busy` so `argosScreenshot()` waits for them. → [Wait for loading](wait-for-loading.md)
+* **Wait for CSS background images to load.** Enable the opt-in `waitForBackgroundImages` option when responsive or decorative backgrounds render late. → [Wait for background images](wait-for-background-images.md)
 * **Make dates and times deterministic.** Hide or freeze any value that changes between runs. → [Stabilize date & time](stabilize-date-and-time.md)
 * **Force consistent text rendering.** Disable subpixel text and font hinting so glyphs look identical on every machine. → [Stabilize text rendering](stabilize-text-rendering.md)
 * **Run the same environment everywhere, and tame rendering quirks.** Use the same OS and browser locally and on CI, and smooth over properties like `border-radius`. → [Browser glitches](browser-glitches.md)

--- a/docs/learn/reliability-and-flakiness/flaky-tests/wait-for-background-images.md
+++ b/docs/learn/reliability-and-flakiness/flaky-tests/wait-for-background-images.md
@@ -1,0 +1,53 @@
+---
+description: >-
+  Wait for CSS background images to load before capturing with the opt-in
+  waitForBackgroundImages stabilization option.
+---
+
+# Wait for background images
+
+CSS background images have no native load event, so the SDK can't wait for them the way it waits for `<img>` elements. When a background image is still loading—or re-fetches on a viewport change, as responsive backgrounds often do—the screenshot can capture a half-painted element and turn flaky.
+
+The `waitForBackgroundImages` stabilization option closes that gap: it discovers background image URLs (including those set on `::before` and `::after`), preloads them, and waits for them to finish before the screenshot is taken.
+
+{% hint style="warning" %}
+Unlike the rest of stabilization, `waitForBackgroundImages` is **disabled by default**. Setting `stabilize: true` does _not_ enable it—you must opt in explicitly. This keeps the extra DOM scan off the path of tests that don't need it.
+{% endhint %}
+
+### Usage
+
+Pass `true` to scan the whole document:
+
+{% tabs %}
+{% tab title="Playwright" %}
+```ts
+await argosScreenshot(page, "homepage", {
+  stabilize: { waitForBackgroundImages: true },
+});
+```
+{% endtab %}
+
+{% tab title="Cypress" %}
+```ts
+cy.argosScreenshot("homepage", {
+  stabilize: { waitForBackgroundImages: true },
+});
+```
+{% endtab %}
+{% endtabs %}
+
+On large pages, narrow the scan to the elements that actually use background images by passing a selector:
+
+```ts
+await argosScreenshot(page, "homepage", {
+  stabilize: { waitForBackgroundImages: { selector: ".hero, [data-bg]" } },
+});
+```
+
+A failed background image (for example a 404) is treated as loaded, so a broken URL never blocks stabilization.
+
+{% hint style="info" %}
+The scan runs once per viewport before the wait begins, so background images added to the DOM _during_ the wait window aren't picked up. For the common responsive-viewport case this is exactly what you want; for `<img>` elements added later, the default `waitForImages` already re-reads the DOM live.
+{% endhint %}
+
+See the full [`stabilize` option reference](../../../sdks-reference/playwright.md) for every stabilization setting.

--- a/docs/sdks-reference/cypress.md
+++ b/docs/sdks-reference/cypress.md
@@ -105,6 +105,7 @@ module.exports = defineConfig({
 * `options.stabilize.waitForAriaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 * `options.stabilize.waitForFonts`: Wait for fonts to be loaded. Default to `true`.
 * `options.stabilize.waitForImages`: Wait for images to be loaded. Default to `true`.
+* `options.stabilize.waitForBackgroundImages`: Wait for CSS background images (including `::before`/`::after`) to load before taking the screenshot. **Disabled by default**—opt in by passing `true` to scan the whole document, or `{ selector: string }` to limit the scan to matching elements. A failed image (e.g. a 404) is treated as loaded so it never blocks stabilization.
 * `options.tag`: Tag or array of tags to attach to the screenshot for filtering in Argos.
 
 ### Helper Attributes for Visual Testing

--- a/docs/sdks-reference/playwright.md
+++ b/docs/sdks-reference/playwright.md
@@ -319,6 +319,7 @@ Each ARIA snapshot counts as an additional screenshot for billing.
 * `options.stabilize.waitForAriaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 * `options.stabilize.waitForFonts`: Wait for fonts to be loaded. Default to `true`.
 * `options.stabilize.waitForImages`: Wait for images to be loaded. Default to `true`.
+* `options.stabilize.waitForBackgroundImages`: Wait for CSS background images (including `::before`/`::after`) to load before taking the screenshot. **Disabled by default**—opt in by passing `true` to scan the whole document, or `{ selector: string }` to limit the scan to matching elements. A failed image (e.g. a 404) is treated as loaded so it never blocks stabilization.
 * `options.beforeScreenshot`: Run a function before taking the screenshot. When using viewports, this function will run before taking screenshots on each viewport.
 * `options.afterScreenshot`: Run a function after taking the screenshot. When using viewports, this function will run after taking screenshots on each viewport.
 * `options.tag`: Tag or array of tags to attach to the screenshot for filtering in Argos.
@@ -345,6 +346,7 @@ Unlike [Playwright's `screenshot` method](https://playwright.dev/docs/api/class-
 * `options.stabilize.waitForAriaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 * `options.stabilize.waitForFonts`: Wait for fonts to be loaded. Default to `true`.
 * `options.stabilize.waitForImages`: Wait for images to be loaded. Default to `true`.
+* `options.stabilize.waitForBackgroundImages`: Wait for CSS background images (including `::before`/`::after`) to load before taking the screenshot. **Disabled by default**—opt in by passing `true` to scan the whole document, or `{ selector: string }` to limit the scan to matching elements. A failed image (e.g. a 404) is treated as loaded so it never blocks stabilization.
 
 #### getCSPScriptHash()
 

--- a/docs/sdks-reference/puppeteer.md
+++ b/docs/sdks-reference/puppeteer.md
@@ -74,6 +74,7 @@ Screenshots are stored in `screenshots/argos` folder, relative to current direct
 * `options.stabilize.waitForAriaBusy`: Wait for the `aria-busy` attribute to be removed from the document. Default to `true`.
 * `options.stabilize.waitForFonts`: Wait for fonts to be loaded. Default to `true`.
 * `options.stabilize.waitForImages`: Wait for images to be loaded. Default to `true`.
+* `options.stabilize.waitForBackgroundImages`: Wait for CSS background images (including `::before`/`::after`) to load before taking the screenshot. **Disabled by default**—opt in by passing `true` to scan the whole document, or `{ selector: string }` to limit the scan to matching elements. A failed image (e.g. a 404) is treated as loaded so it never blocks stabilization.
 * `options.tag`: Tag or array of tags to attach to the screenshot for filtering in Argos.
 
 Unlike [Puppeteer's `screenshot` method](https://playwright.dev/docs/api/class-page#page-screenshot), `argosScreenshot` set `fullPage` option to `true` by default. Feel free to override this option if you prefer partial screenshots of your pages.


### PR DESCRIPTION
## Summary

Documents the new opt-in `waitForBackgroundImages` stabilization option introduced in [argos-ci/argos-javascript#324](https://github.com/argos-ci/argos-javascript/pull/324), which waits for CSS background images to load before capturing.

## Changes

- Add `options.stabilize.waitForBackgroundImages` to the **Playwright** (both `argosScreenshot` and `argosAriaSnapshot` blocks), **Cypress**, and **Puppeteer** SDK references, explicitly noting it is **disabled by default** and must be opted into.
- Add a dedicated **Wait for background images** page to the flaky tests playbook, explaining when responsive/decorative backgrounds cause flakiness and how to enable the option (whole-document or scoped by selector).
- Wire the new page into `SUMMARY.md` and the flaky tests playbook index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)