### PR TITLE
docs: document the 50 MB snapshot upload size limit

### DIFF
--- a/docs/sdks-reference/argos-command-line-interface-cli.md
+++ b/docs/sdks-reference/argos-command-line-interface-cli.md
@@ -110,6 +110,10 @@ bun x argos upload ./screenshots
 {% endtab %}
 {% endtabs %}
 
+#### Snapshot size limit
+
+Each snapshot uploaded to Argos is limited to **50 MB**. This applies to every artifact type — a screenshot, a [non-image snapshot](#compare-non-image-files), or a [Playwright trace](playwright.md). Files larger than 50 MB are skipped and won't appear in your build.
+
 #### Compare non-image files
 
 Use `-f` or `--files` to upload text-based artifacts such as JSON, YAML, XML, HTML, Markdown, CSS, or JavaScript files. See [Compare non-image files](../learn/how-to-guides/visual-coverage/compare-non-image-files.md) for examples and the full list of supported content types.

--- a/docs/sdks-reference/playwright.md
+++ b/docs/sdks-reference/playwright.md
@@ -65,6 +65,10 @@ The Argos Playwright reporter automatically reports failure screenshots and play
 * **Failure Screenshots**: View failure screenshots from your CI tests directly in Argos. No extra steps, just immediate clarity where you need it most.
 * **Playwright Traces**: “Time travel” through your failing tests with remote Playwright traces. Gain a complete, step-by-step visual journey to the heart of any test issue.
 
+{% hint style="info" %}
+Each uploaded snapshot — including screenshots and Playwright traces — is limited to 50 MB. See [Snapshot size limit](argos-command-line-interface-cli.md#snapshot-size-limit).
+{% endhint %}
+
 To enable Test Debugging, you have to add Argos reporter and to turn on [Playwright test use options](https://playwright.dev/docs/test-use-options) in your Playwright config:
 
 {% code title="playwright.config.ts" %}


### PR DESCRIPTION
## What

Documents that every snapshot uploaded to Argos is limited to **50 MB**, covering all three artifact types: a screenshot, a non-image snapshot, or a Playwright trace.

## Where

- **Primary** — new `Snapshot size limit` subsection in the CLI **Upload Command** reference ([`sdks-reference/argos-command-line-interface-cli.md`](docs/sdks-reference/argos-command-line-interface-cli.md)). This is the canonical upload reference and the most discoverable single home; it already links down to the non-image-files guide.
- **Cross-reference** — an info hint in the Playwright SDK **Setup Tests Debugging** section ([`sdks-reference/playwright.md`](docs/sdks-reference/playwright.md)), since Playwright traces are uploaded by the reporter rather than the CLI.

## Note

I phrased the over-limit behavior as *"Files larger than 50 MB are skipped and won't appear in your build."* Worth confirming this matches the actual behavior (skipped vs. build error vs. truncated) before merge, since merging publishes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)